### PR TITLE
Convert JogAmp and slf4j dependencies to compileOnly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changed
 - Make `GLCapabilitiesFactory` internal in `glimpse-ui`
 - Setting fixed surface scale in `GlimpsePanel` with parameter `fixedScale`
+- Convert JogAmp and slf4j dependencies to `compileOnly`
 
 ## [1.0.0-ALPHA3]
 ### Changed

--- a/glimpse/core/build.gradle.kts
+++ b/glimpse/core/build.gradle.kts
@@ -39,9 +39,9 @@ kotlin {
         }
         val desktopMain by getting {
             dependencies {
-                implementation("org.jogamp.jogl:jogl-all-main:2.3.2")
-                implementation("org.jogamp.gluegen:gluegen-rt-main:2.3.2")
-                implementation("org.slf4j:slf4j-api:1.7.30")
+                compileOnly("org.jogamp.jogl:jogl-all-main:2.3.2")
+                compileOnly("org.jogamp.gluegen:gluegen-rt-main:2.3.2")
+                compileOnly("org.slf4j:slf4j-api:1.7.30")
             }
         }
         val desktopTest by getting {

--- a/glimpse/obj/build.gradle.kts
+++ b/glimpse/obj/build.gradle.kts
@@ -39,9 +39,9 @@ kotlin {
         }
         val desktopMain by getting {
             dependencies {
-                implementation("org.jogamp.jogl:jogl-all-main:2.3.2")
-                implementation("org.jogamp.gluegen:gluegen-rt-main:2.3.2")
-                implementation("org.slf4j:slf4j-api:1.7.30")
+                compileOnly("org.jogamp.jogl:jogl-all-main:2.3.2")
+                compileOnly("org.jogamp.gluegen:gluegen-rt-main:2.3.2")
+                compileOnly("org.slf4j:slf4j-api:1.7.30")
             }
         }
         val desktopTest by getting {

--- a/glimpse/offscreen/build.gradle.kts
+++ b/glimpse/offscreen/build.gradle.kts
@@ -43,9 +43,9 @@ kotlin {
         }
         val desktopMain by getting {
             dependencies {
-                implementation("org.jogamp.jogl:jogl-all-main:2.3.2")
-                implementation("org.jogamp.gluegen:gluegen-rt-main:2.3.2")
-                implementation("org.slf4j:slf4j-api:1.7.30")
+                compileOnly("org.jogamp.jogl:jogl-all-main:2.3.2")
+                compileOnly("org.jogamp.gluegen:gluegen-rt-main:2.3.2")
+                compileOnly("org.slf4j:slf4j-api:1.7.30")
             }
         }
         val desktopTest by getting {

--- a/glimpse/ui-compose/build.gradle.kts
+++ b/glimpse/ui-compose/build.gradle.kts
@@ -44,9 +44,9 @@ kotlin {
         }
         val desktopMain by getting {
             dependencies {
-                implementation("org.jogamp.jogl:jogl-all-main:2.3.2")
-                implementation("org.jogamp.gluegen:gluegen-rt-main:2.3.2")
-                implementation("org.slf4j:slf4j-api:1.7.30")
+                compileOnly("org.jogamp.jogl:jogl-all-main:2.3.2")
+                compileOnly("org.jogamp.gluegen:gluegen-rt-main:2.3.2")
+                compileOnly("org.slf4j:slf4j-api:1.7.30")
             }
         }
         val desktopTest by getting {

--- a/glimpse/ui/build.gradle.kts
+++ b/glimpse/ui/build.gradle.kts
@@ -39,9 +39,9 @@ kotlin {
         }
         val desktopMain by getting {
             dependencies {
-                implementation("org.jogamp.jogl:jogl-all-main:2.3.2")
-                implementation("org.jogamp.gluegen:gluegen-rt-main:2.3.2")
-                implementation("org.slf4j:slf4j-api:1.7.30")
+                compileOnly("org.jogamp.jogl:jogl-all-main:2.3.2")
+                compileOnly("org.jogamp.gluegen:gluegen-rt-main:2.3.2")
+                compileOnly("org.slf4j:slf4j-api:1.7.30")
             }
         }
         val desktopTest by getting {


### PR DESCRIPTION
For some use cases, either (or both) of the libraries are already bundled in the application, and should not be included twice